### PR TITLE
redactor: use PORT environment variable dynamically

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,11 +28,14 @@ async fn fake_news() -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    let port = port.parse::<u16>().expect("PORT must be a number");
+
     HttpServer::new(|| {
         App::new()
             .service(fake_news)
     })
-    .bind("0.0.0.0:8080")?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
 }


### PR DESCRIPTION
This pull request addresses an issue where the deployment process on Render was failing due to a loop in port detection. The problem was that the application was not correctly binding to the port specified by Render, leading to repeated attempts to detect the open port.

Changes Made:
- Modified the main.rs file to read the port number from the PORT environment variable provided by Render
- Added error handling to ensure the port number is a valid integer.
- Updated the server binding to use the parsed port number.

Detailed Changes:

Environment Variable Reading:
- Added code to read the PORT environment variable using std::env::var.
- Provided a default value of 8080 if the environment variable is not set.

Port Parsing and Error Handling:
- Parsed the port number to a u16 type and added error handling to ensure the port number is valid.

Server Binding:
- Updated the HttpServer::bind method to use the parsed port number, allowing Render to correctly detect the open port.