### PR TITLE
Add Dependabot configuration for cargo and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'cargo' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'daily'
+
+  - package-ecosystem: 'github-actions'
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
This pull request adds the necessary configuration files for Dependabot to update dependencies in the cargo package ecosystem and GitHub Actions workflows. The Dependabot configuration specifies the location of the package manifests and sets a daily update schedule for both cargo dependencies and GitHub Actions workflows. This will help ensure that our project stays up to date with the latest versions of dependencies and workflows.